### PR TITLE
we can use the http api now, stop using ssh

### DIFF
--- a/proxstar/proxmox.py
+++ b/proxstar/proxmox.py
@@ -45,7 +45,8 @@ def connect_proxmox_ssh():
 
 def get_node_least_mem(proxmox):
     nodes = proxmox.nodes.get()
-    sorted_nodes = sorted(nodes, key=lambda x: x['mem'])
+    sorted_nodes = sorted(
+        nodes, key=lambda x: ('mem' not in x, x.get('mem', None)))
     return sorted_nodes[0]['node']
 
 

--- a/proxstar/templates/base.html
+++ b/proxstar/templates/base.html
@@ -9,7 +9,6 @@
     <link rel="stylesheet" href="https://themeswitcher.csh.rit.edu/api/get" media="screen">
     <link rel="stylesheet" href="/static/css/styles.css">
     <link rel="stylesheet" href="/static/css/circle.css">
-    <link rel="manifest" href="/static/manifest.json">
 </head>
 <body>
 {% block nav %}

--- a/proxstar/vm.py
+++ b/proxstar/vm.py
@@ -7,8 +7,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 from proxstar import db, starrs
 from proxstar.db import delete_vm_expire, get_vm_expire
-from proxstar.proxmox import (connect_proxmox, connect_proxmox_ssh,
-                              get_free_vmid, get_node_least_mem, get_vm_node)
+from proxstar.proxmox import connect_proxmox, get_free_vmid, get_node_least_mem, get_vm_node
 from proxstar.starrs import get_ip_for_mac
 from proxstar.util import lazy_property
 
@@ -236,18 +235,18 @@ class VM(object):
 
     @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
     def set_ci_user(self, user):
-        proxmox = connect_proxmox_ssh()
+        proxmox = connect_proxmox()
         proxmox.nodes(self.node).qemu(self.id).config.put(ciuser=user)
 
     @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
     def set_ci_ssh_key(self, ssh_key):
-        proxmox = connect_proxmox_ssh()
+        proxmox = connect_proxmox()
         escaped_key = urllib.parse.quote(ssh_key, safe='')
-        proxmox.nodes(self.node).qemu(self.id).config.put(sshkey=escaped_key)
+        proxmox.nodes(self.node).qemu(self.id).config.put(sshkeys=escaped_key)
 
     @retry(wait=wait_fixed(2), stop=stop_after_attempt(5))
     def set_ci_network(self):
-        proxmox = connect_proxmox_ssh()
+        proxmox = connect_proxmox()
         proxmox.nodes(self.node).qemu(self.id).config.put(ipconfig0='ip=dhcp')
 
 


### PR DESCRIPTION
We can use the HTTP API to do the cloud-init stuff, let's start using it since the SSH backend is borked.

Also fixed grabbing the least memory node if a node is down.